### PR TITLE
Makehook: fixes improper adding `www.` to redirection domains

### DIFF
--- a/makehook.js
+++ b/makehook.js
@@ -12,7 +12,7 @@ function onGot(item) {
     newloc = newloc.replace("m.youtube.com", instance);
   }
   else if (newloc.includes("youtube")) {
-    newloc = newloc.replace("youtube.com", instance);
+    newloc = newloc.replace("www.youtube.com", instance);
   }
   else if (newloc.includes("youtu.be")) {
     newloc = newloc.replace("youtu.be/", instance + "/watch?v=");


### PR DESCRIPTION
* href returned `https://www.youtube.com/...`
* the string replacement only replaces `youtube.com` by invidous domain given
* this leads to a wrong `www.` in front of some domains
* for the original `invidio.us` domain this did not matter since `www.invidio.us` works, too

Should solve #20 at least partially.